### PR TITLE
Make n8n data mount path configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ main:
     enabled: false
     # what type volume, possible options are [existing, emptyDir, dynamic] dynamic for Dynamic Volume Provisioning, existing for using an existing Claim
     type: emptyDir
+    # Path where the data volume is mounted
+    mountPath: /home/node/.n8n
     # Persistent Volume Storage Class
     # If defined, storageClassName: <storageClass>
     # If set to "-", storageClassName: "", which disables dynamic provisioning
@@ -322,10 +324,10 @@ main:
   initContainers: []
   #    - name: init-data-dir
   #      image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-  #      command: [ "/bin/sh", "-c", "mkdir -p /home/node/.n8n/" ]
+  #      command: [ "/bin/sh", "-c", "mkdir -p {{ .Values.main.persistence.mountPath }}/" ]
   #      volumeMounts:
   #        - name: data
-  #          mountPath: /home/node/.n8n
+  #          mountPath: {{ .Values.main.persistence.mountPath }}
 
 
   service:
@@ -387,6 +389,8 @@ worker:
     enabled: false
     # what type volume, possible options are [existing, emptyDir, dynamic] dynamic for Dynamic Volume Provisioning, existing for using an existing Claim
     type: emptyDir
+    # Path where the data volume is mounted
+    mountPath: /home/node/.n8n
     # Persistent Volume Storage Class
     # If defined, storageClassName: <storageClass>
     # If set to "-", storageClassName: "", which disables dynamic provisioning
@@ -569,6 +573,8 @@ webhook:
     enabled: false
     # what type volume, possible options are [existing, emptyDir, dynamic] dynamic for Dynamic Volume Provisioning, existing for using an existing Claim
     type: emptyDir
+    # Path where the data volume is mounted
+    mountPath: /home/node/.n8n
     # Persistent Volume Storage Class
     # If defined, storageClassName: <storageClass>
     # If set to "-", storageClassName: "", which disables dynamic provisioning

--- a/charts/n8n/templates/deployment.webhook.yaml
+++ b/charts/n8n/templates/deployment.webhook.yaml
@@ -114,7 +114,7 @@ spec:
             {{- toYaml .Values.webhook.resources | nindent 12 }}
           volumeMounts:
             - name: data
-              mountPath: /home/node/.n8n
+              mountPath: {{ .Values.main.persistence.mountPath | default "/home/node/.n8n" }}
           {{- if .Values.webhook.extraVolumeMounts }}
             {{- toYaml .Values.webhook.extraVolumeMounts | nindent 12 }}
           {{- end }}

--- a/charts/n8n/templates/deployment.worker.yaml
+++ b/charts/n8n/templates/deployment.worker.yaml
@@ -110,7 +110,7 @@ spec:
             {{- toYaml .Values.worker.resources | nindent 12 }}
           volumeMounts:
             - name: data
-              mountPath: /home/node/.n8n
+              mountPath: {{ .Values.main.persistence.mountPath | default "/home/node/.n8n" }}
           {{- if .Values.worker.extraVolumeMounts }}
             {{- toYaml .Values.worker.extraVolumeMounts | nindent 12 }}
           {{- end }}

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -95,7 +95,7 @@ spec:
             {{- toYaml .Values.main.resources | nindent 12 }}
           volumeMounts:
             - name: data
-              mountPath: /home/node/.n8n
+              mountPath: {{ .Values.main.persistence.mountPath | default "/home/node/.n8n" }}
           {{- if .Values.main.extraVolumeMounts }}
             {{- toYaml .Values.main.extraVolumeMounts | nindent 12 }}
           {{- end }}

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -83,6 +83,8 @@ main:
     enabled: false
     # what type volume, possible options are [existing, emptyDir, dynamic] dynamic for Dynamic Volume Provisioning, existing for using an existing Claim
     type: emptyDir
+    # Path where the data volume is mounted
+    mountPath: /home/node/.n8n
     # Persistent Volume Storage Class
     # If defined, storageClassName: <storageClass>
     # If set to "-", storageClassName: "", which disables dynamic provisioning


### PR DESCRIPTION
## Summary
- add `mountPath` option under `main.persistence`
- reference mountPath in deployments
- document mountPath usage in README

## Testing
- `helm lint charts/n8n`
- `helm template test charts/n8n`

------
https://chatgpt.com/codex/tasks/task_b_68895c55dd6c832e843fb3b026ec6591